### PR TITLE
Add multi-tenancy-notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.env
+venv
 integrations/llamaindex/indexes-episode2/.devcontainer/Dockerfile
 integrations/llamaindex/indexes-episode2/.devcontainer/devcontainer.json
 integrations/llama2-demo/.devcontainer/devcontainer.json

--- a/multi-tenancy/multi-tenancy-example.ipynb
+++ b/multi-tenancy/multi-tenancy-example.ipynb
@@ -1,0 +1,374 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🗂️ Multi-Tenancy in Weaviate\n",
+    "\n",
+    "Welcome to this demo notebook! Here, we'll walk you through a small example showcasing the `Multi-Tenancy` function in Weaviate.\n",
+    "Multi-tenancy is a key feature in Weaviate, allowing for the efficient and secure management of data across multiple users or tenants.\n",
+    "\n",
+    "## 📖 Further Reading:\n",
+    "\n",
+    "- Explore the concept in depth in the [multi-tenancy blog post](https://weaviate.io/blog/multi-tenancy-vector-search).\n",
+    "- Dive into the technical details in our [Weaviate developer documentation](https://weaviate.io/developers/weaviate/manage-data/multi-tenancy#enable-multitenancy).\n",
+    "\n",
+    "## Getting started\n",
+    "Before we dive in, there are a few preliminary steps:\n",
+    "\n",
+    "1. Set Up a Weaviate Cluster: \n",
+    "This notebook requires a working Weaviate cluster. If you don't have one, fret not! You can set up a free sandbox Weaviate cluster by following our [comprehensive guide](https://weaviate.io/developers/academy/zero_to_mvp/hello_weaviate/set_up).\n",
+    "\n",
+    "2. Virtual Environment and Dependencies: \n",
+    "To ensure smooth execution and prevent potential conflicts with your global Python environment, we recommend running the code in a virtual environment. Later in this notebook, we'll guide you through setting up this environment and installing the necessary dependencies.\n",
+    "\n",
+    "With these points in mind, let's get started!"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dependencies\n",
+    "\n",
+    "Before proceeding with the notebook content, it's essential to set up an isolated Python environment. This helps avoid any potential package conflicts and ensures that you have a clean workspace.\n",
+    "\n",
+    "### Virtual Environment Setup:\n",
+    "\n",
+    "If you haven't created a virtual environment before, here's how you can do it:\n",
+    "\n",
+    "Using `virtualenv`:\n",
+    "\n",
+    "```bash\n",
+    "pip install virtualenv\n",
+    "python -m virtualenv venv\n",
+    "```\n",
+    "\n",
+    "Using `venv` (built-in with Python 3.3+):\n",
+    "\n",
+    "```bash\n",
+    "python -m venv venv\n",
+    "```\n",
+    "\n",
+    "After creating the virtual environment, you need to activate it:\n",
+    "\n",
+    "Windows:\n",
+    "\n",
+    "```bash\n",
+    ".\\venv\\Scripts\\activate\n",
+    "```\n",
+    "macOS and Linux:\n",
+    "\n",
+    "```bash\n",
+    "source venv/bin/activate\n",
+    "```\n",
+    "### Installing Dependencies:\n",
+    "\n",
+    "With the virtual environment active, run the following code to install all the required dependencies for this notebook:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: weaviate-client in ./venv/lib/python3.10/site-packages (3.22.1)\n",
+      "Requirement already satisfied: requests<=2.31.0,>=2.28.0 in ./venv/lib/python3.10/site-packages (from weaviate-client) (2.31.0)\n",
+      "Requirement already satisfied: validators<=0.21.0,>=0.18.2 in ./venv/lib/python3.10/site-packages (from weaviate-client) (0.20.0)\n",
+      "Requirement already satisfied: tqdm<5.0.0,>=4.59.0 in ./venv/lib/python3.10/site-packages (from weaviate-client) (4.66.0)\n",
+      "Requirement already satisfied: authlib>=1.1.0 in ./venv/lib/python3.10/site-packages (from weaviate-client) (1.2.1)\n",
+      "Requirement already satisfied: cryptography>=3.2 in ./venv/lib/python3.10/site-packages (from authlib>=1.1.0->weaviate-client) (41.0.3)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in ./venv/lib/python3.10/site-packages (from requests<=2.31.0,>=2.28.0->weaviate-client) (3.2.0)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in ./venv/lib/python3.10/site-packages (from requests<=2.31.0,>=2.28.0->weaviate-client) (3.4)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in ./venv/lib/python3.10/site-packages (from requests<=2.31.0,>=2.28.0->weaviate-client) (2.0.4)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in ./venv/lib/python3.10/site-packages (from requests<=2.31.0,>=2.28.0->weaviate-client) (2023.7.22)\n",
+      "Requirement already satisfied: decorator>=3.4.0 in ./venv/lib/python3.10/site-packages (from validators<=0.21.0,>=0.18.2->weaviate-client) (5.1.1)\n",
+      "Requirement already satisfied: cffi>=1.12 in ./venv/lib/python3.10/site-packages (from cryptography>=3.2->authlib>=1.1.0->weaviate-client) (1.15.1)\n",
+      "Requirement already satisfied: pycparser in ./venv/lib/python3.10/site-packages (from cffi>=1.12->cryptography>=3.2->authlib>=1.1.0->weaviate-client) (2.21)\n",
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.1.2\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.2.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install weaviate-client"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Connecting to Your Weaviate Cluster\n",
+    "\n",
+    "To interact with our Weaviate cluster, we'll initialize a client object. Once set up, we'll retrieve the current schemas as a way to verify the connection. Since the cluster is newly created, we expect that no schemas will be present."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "import weaviate\n",
+    "\n",
+    "client = weaviate.Client(\n",
+    "  url=\"WEAVIATE-INSTANCE-URL\",  # URL of your Weaviate instance\n",
+    "  auth_client_secret=weaviate.AuthApiKey(api_key=\"AUTH-KEY\"), # (Optional) If the Weaviate instance requires authentication\n",
+    ")\n",
+    "\n",
+    "client.schema.delete_all() # Delete all data\n",
+    "is_valid = len(client.schema.get()[\"classes\"]) == 0\n",
+    "print(is_valid)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setting Up Multi-Tenancy in a Weaviate Class\n",
+    "\n",
+    "In Weaviate, multi-tenancy allows for multiple tenants to securely access and manage data within the same schema. Let's proceed to define a new class that utilizes this feature:\n",
+    "\n",
+    "### Define a Multi-Tenancy Enabled Class:\n",
+    "We'll start by creating a class named 'MultiTenancyClass' with the multi-tenancy feature activated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from weaviate import Tenant\n",
+    "\n",
+    "client.schema.create_class({\n",
+    "    'class': 'MultiTenancyClass',\n",
+    "    'multiTenancyConfig': {'enabled': True}\n",
+    "})"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Add Multiple Tenants to the Class:\n",
+    "After establishing the class, we'll associate it with two tenants: 'tenantA' and 'tenantB'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.schema.add_class_tenants(\n",
+    "  class_name='MultiTenancyClass',  # The class to which the tenants will be added\n",
+    "  tenants=[Tenant(name='tenantA'), Tenant(name='tenantB')]\n",
+    ")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fetching Tenants from a Weaviate Class\n",
+    "\n",
+    "To view the tenants associated with a specific class, we can retrieve a list of all the tenants linked to it. Let's do this for our previously created class, 'MultiTenancyClass':"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Tenant(name='tenantA'), Tenant(name='tenantB')]\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "tenants = client.schema.get_class_tenants(\n",
+    "    class_name='MultiTenancyClass'  # The class from which the tenants will be retrieved\n",
+    ")\n",
+    "\n",
+    "print(tenants)\n",
+    "is_valid = len(tenants) == 2\n",
+    "print(is_valid)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Assigning Data Objects to Specific Tenants\n",
+    "\n",
+    "In Weaviate, data objects can be associated with specific tenants in a multi-tenancy enabled class. Here, we will demonstrate how to create data objects and link them to their respective tenants:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "object_a = client.data_object.create(\n",
+    "      class_name='MultiTenancyClass',  # The class to which the object will be added\n",
+    "      data_object={\n",
+    "          'text': 'This belongs to TenantA'\n",
+    "      },\n",
+    "      tenant='tenantA'  # The tenant to which the object will be added\n",
+    ")\n",
+    "\n",
+    "# First object\n",
+    "object_b_1 = client.data_object.create(\n",
+    "      class_name='MultiTenancyClass',  \n",
+    "      data_object={\n",
+    "          'text': 'This belongs to TenantB'\n",
+    "      },\n",
+    "      tenant='tenantB'  \n",
+    ")\n",
+    "\n",
+    "# Second object\n",
+    "object_b_2 = client.data_object.create(\n",
+    "      class_name='MultiTenancyClass',  \n",
+    "      data_object={\n",
+    "          'text': 'This also belongs to TenantB'\n",
+    "      },\n",
+    "      tenant='tenantB'  \n",
+    ")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Performing Tenant-Specific Queries\n",
+    "\n",
+    "By leveraging the multi-tenancy functionality, we can conduct queries that are specific to individual tenants. This enables us to fetch data solely associated with a designated tenant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TenantA: [{'text': 'This belongs to TenantA'}]\n",
+      "TenantB: [{'text': 'This also belongs to TenantB'}, {'text': 'This belongs to TenantB'}]\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "result_a = (\n",
+    "    client.query.get('MultiTenancyClass', ['text'])\n",
+    "    .with_tenant('tenantA')\n",
+    "    .do()\n",
+    ")\n",
+    "\n",
+    "result_b = (\n",
+    "    client.query.get('MultiTenancyClass', ['text'])\n",
+    "    .with_tenant('tenantB')\n",
+    "    .do()\n",
+    ")\n",
+    "\n",
+    "print(f\"TenantA: {result_a['data']['Get']['MultiTenancyClass']}\")\n",
+    "print(f\"TenantB: {result_b['data']['Get']['MultiTenancyClass']}\")\n",
+    "\n",
+    "is_valid = len(result_a[\"data\"][\"Get\"][\"MultiTenancyClass\"]) == 1 and len(result_b[\"data\"][\"Get\"][\"MultiTenancyClass\"]) == 2\n",
+    "print(is_valid)\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Removing Tenants from a Weaviate Class\n",
+    "\n",
+    "In situations where specific tenants are no longer required, Weaviate allows us to remove them from a class. This action will only affect the specified tenants, leaving other associated tenants unaffected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Tenant(name='tenantA')]\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "client.schema.remove_class_tenants(\n",
+    "    class_name='MultiTenancyClass',  # The class from which the tenants will be removed\n",
+    "    tenants=['tenantB', 'tenantX']  # The tenants to be removed. tenantX will be ignored.\n",
+    ")\n",
+    "\n",
+    "tenants = client.schema.get_class_tenants(\n",
+    "    class_name='MultiTenancyClass'  # The class from which the tenants will be retrieved\n",
+    ")\n",
+    "\n",
+    "print(tenants)\n",
+    "is_valid = len(tenants) == 1\n",
+    "print(is_valid)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This `PR` adds a demo notebook for the new multi-tenancy feature in Weaviate. It uses code from the weaviate [documentation](https://weaviate.io/developers/weaviate/manage-data/multi-tenancy#enable-multitenancy)

It shows following features:
- Create classes with multi-tenancy enabled
- Create tenants
- List tenants
- Add objects to tenants
- Search objects within tenants
- Delete tenants