### PR TITLE
Fix the typo of advanced_rag.ipynb

### DIFF
--- a/integrations/llamaindex/retrieval-augmented-generation/advanced_rag.ipynb
+++ b/integrations/llamaindex/retrieval-augmented-generation/advanced_rag.ipynb
@@ -38,7 +38,7 @@
     }
    ],
    "source": [
-    "# !pip3 install llama_index\n",
+    "# !pip3 install llama-index\n",
     "\n",
     "# Use this to upgrade from an older llama_index version to v0.10.1\n",
     "# !pip3 uninstall llama-index\n",


### PR DESCRIPTION
Fix the typo of `pip3 install llama_index` 