### PR TITLE
llm-frameworks langchain use create_retrieval_chain

### DIFF
--- a/integrations/llm-frameworks/langchain/loading-data/langchain-simple-pdf.ipynb
+++ b/integrations/llm-frameworks/langchain/loading-data/langchain-simple-pdf.ipynb
@@ -87,19 +87,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Started /Users/dudanogueira/.cache/weaviate-embedded: process ID 24677\n"
+      "Started /Users/dudanogueira/.cache/weaviate-embedded: process ID 82297\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "{\"action\":\"startup\",\"default_vectorizer_module\":\"none\",\"level\":\"info\",\"msg\":\"the default vectorizer modules is set to \\\"none\\\", as a result all new schema classes without an explicit vectorizer setting, will use this vectorizer\",\"time\":\"2024-08-07T17:56:39-03:00\"}\n",
-      "{\"action\":\"startup\",\"auto_schema_enabled\":true,\"level\":\"info\",\"msg\":\"auto schema enabled setting is set to \\\"true\\\"\",\"time\":\"2024-08-07T17:56:39-03:00\"}\n",
-      "{\"level\":\"info\",\"msg\":\"No resource limits set, weaviate will use all available memory and CPU. To limit resources, set LIMIT_RESOURCES=true\",\"time\":\"2024-08-07T17:56:39-03:00\"}\n",
-      "{\"level\":\"warning\",\"msg\":\"Multiple vector spaces are present, GraphQL Explore and REST API list objects endpoint module include params has been disabled as a result.\",\"time\":\"2024-08-07T17:56:39-03:00\"}\n",
-      "{\"action\":\"grpc_startup\",\"level\":\"info\",\"msg\":\"grpc server listening at [::]:50050\",\"time\":\"2024-08-07T17:56:39-03:00\"}\n",
-      "{\"action\":\"restapi_management\",\"level\":\"info\",\"msg\":\"Serving weaviate at http://127.0.0.1:8079\",\"time\":\"2024-08-07T17:56:39-03:00\"}\n"
+      "{\"action\":\"startup\",\"default_vectorizer_module\":\"none\",\"level\":\"info\",\"msg\":\"the default vectorizer modules is set to \\\"none\\\", as a result all new schema classes without an explicit vectorizer setting, will use this vectorizer\",\"time\":\"2024-08-09T10:09:59-03:00\"}\n",
+      "{\"action\":\"startup\",\"auto_schema_enabled\":true,\"level\":\"info\",\"msg\":\"auto schema enabled setting is set to \\\"true\\\"\",\"time\":\"2024-08-09T10:09:59-03:00\"}\n",
+      "{\"level\":\"info\",\"msg\":\"No resource limits set, weaviate will use all available memory and CPU. To limit resources, set LIMIT_RESOURCES=true\",\"time\":\"2024-08-09T10:09:59-03:00\"}\n",
+      "{\"level\":\"warning\",\"msg\":\"Multiple vector spaces are present, GraphQL Explore and REST API list objects endpoint module include params has been disabled as a result.\",\"time\":\"2024-08-09T10:09:59-03:00\"}\n",
+      "{\"action\":\"grpc_startup\",\"level\":\"info\",\"msg\":\"grpc server listening at [::]:50050\",\"time\":\"2024-08-09T10:09:59-03:00\"}\n",
+      "{\"action\":\"restapi_management\",\"level\":\"info\",\"msg\":\"Serving weaviate at http://127.0.0.1:8079\",\"time\":\"2024-08-09T10:09:59-03:00\"}\n"
      ]
     },
     {
@@ -107,14 +107,6 @@
      "output_type": "stream",
      "text": [
       "Client is Ready? True\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "{\"level\":\"info\",\"msg\":\"Completed loading shard wikipedialangchain_auivLQOdCFVz in 7.039875ms\",\"time\":\"2024-08-07T17:56:40-03:00\"}\n",
-      "{\"action\":\"hnsw_vector_cache_prefill\",\"count\":3000,\"index_id\":\"main\",\"level\":\"info\",\"limit\":1000000000000,\"msg\":\"prefilled vector cache\",\"time\":\"2024-08-07T17:56:40-03:00\",\"took\":4174791}\n"
      ]
     }
    ],
@@ -148,8 +140,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "{\"level\":\"info\",\"msg\":\"Created shard wikipedialangchain_XlrB2ziP9VQ6 in 1.016583ms\",\"time\":\"2024-08-07T17:56:50-03:00\"}\n",
-      "{\"action\":\"hnsw_vector_cache_prefill\",\"count\":1000,\"index_id\":\"main\",\"level\":\"info\",\"limit\":1000000000000,\"msg\":\"prefilled vector cache\",\"time\":\"2024-08-07T17:56:50-03:00\",\"took\":51458}\n"
+      "{\"level\":\"info\",\"msg\":\"Created shard wikipedialangchain_DA22dHFtJhKY in 841.375µs\",\"time\":\"2024-08-09T10:09:59-03:00\"}\n",
+      "{\"action\":\"hnsw_vector_cache_prefill\",\"count\":1000,\"index_id\":\"main\",\"level\":\"info\",\"limit\":1000000000000,\"msg\":\"prefilled vector cache\",\"time\":\"2024-08-09T10:09:59-03:00\",\"took\":33875}\n"
      ]
     }
    ],
@@ -324,10 +316,12 @@
      "output_type": "stream",
      "text": [
       "brazil-wikipedia-article-text.pdf\n",
-      "11.0\n",
-      "European Portuguese (despite a very substantial number of Portuguese colonial settlers, and more recent immigrants,\n",
-      "coming from Northern regions, and in minor degree Portuguese Macaronesia), with a few influences from the Amerindian\n",
-      "and African languages, especially West African and Bantu restricted to the vocabulary only. As a result, the language is\n"
+      "10.0\n",
+      "cafuzos\n",
+      " (descendants of Afro-Brazilians and\n",
+      "Natives). Higher percents of Blacks, mulattoes and tri-racials can be found in the eastern coast of the Northeastern region\n",
+      "from Bahia to Paraíba and also in northern Maranhão, southern Minas Gerais and in eastern Rio de Janeiro.\n",
+      "People of considerable Amerindian ancestry form the majority of the population in the Northern, Northeastern and Center-\n"
      ]
     }
    ],
@@ -346,14 +340,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "La nourriture traditionnelle du Brésil comprend des plats tels que la farine (farofa), les pommes de terre frites, la cassave frite, la banane frite, la viande frite et le fromage frit. Des snacks populaires incluent le pastel (une pâtisserie frite), la coxinha (une variation de croquette de poulet), le pão de queijo (pain au fromage et farine de manioc / tapioca), la pamonha (pâte de maïs et de lait), l'esfirra (une variation de pâtisserie libanaise) et l'acarajé (de la cuisine africaine). Les plats traditionnels incluent la feijoada, considérée comme le plat national du pays, ainsi que des plats régionaux tels que le beiju, le feijão tropeiro, le vatapá, la moqueca, la polenta (de la cuisine italienne), le kibbeh (de la cuisine arabe), l'empanada et l'empada. Les desserts brésiliens comprennent des douceurs comme les brigadeiros (boules de fudge au chocolat), le bolo de rolo (gâteau roulé à la goiabada), la cocada (une douceur à la noix de coco), les beijinhos (truffes à la noix de coco et au clou de girofle) et le Romeu e Julieta (fromage avec de la goiabada). Les boissons traditionnelles incluent le café et la cachaça, une liqueur brésilienne distillée à partir de canne à sucre et utilisée dans le cocktail national, la Caipirinha.\n"
+      "La nourriture traditionnelle du Brésil comprend des plats tels que la farine (farofa), les pommes de terre frites, la cassave frite, la banane frite, la viande frite et le fromage frit. Les snacks populaires incluent le pastel (une pâtisserie frite), la coxinha (une variation de croquette de poulet), le pão de queijo (pain au fromage et farine de manioc / tapioca), la pamonha (pâte de maïs et de lait), l'esfirra (une variation de pâtisserie libanaise) et l'acarajé (de la cuisine africaine). Les plats traditionnels incluent la feijoada, considérée comme le plat national du pays, ainsi que des plats régionaux tels que le beiju, le feijão tropeiro, le vatapá, la moqueca, la polenta (de la cuisine italienne), le kibbeh (de la cuisine arabe), l'empanada et l'empada. Les desserts brésiliens comprennent des mets tels que les brigadeiros (boules de fudge au chocolat), le bolo de rolo (gâteau roulé à la goiabada), la cocada (une douceur à la noix de coco), les beijinhos (truffes à la noix de coco et au clou de girofle) et le Romeu e Julieta (fromage avec de la goiabada). Les boissons traditionnelles incluent le café et la cachaça, une liqueur brésilienne distillée à partir de canne à sucre et utilisée dans le cocktail national, la Caipirinha.\n"
      ]
     }
    ],
@@ -384,7 +378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -398,9 +392,9 @@
       "{'text': 'make paçoca, rapadura and pé-de-moleque. Local common fruits like açaí, cupuaçu, mango, papaya, cocoa, cashew,\\nguava, orange, lime, passionfruit, pineapple, and hog plum are turned in juices and used to make chocolates, ice pops and\\nice cream.\\nCinema\\nThe Brazilian film industry began in the late 19th century, during the early days of the Belle Époque. While there were', 'page': 13.0, 'source': 'brazil-wikipedia-article-text.pdf'}\n",
       "{'text': 'especially in the twentieth century.\\nPopular music since the late eighteenth century began to show signs of forming a characteristically Brazilian sound, with\\nsamba considered the most typical and on the UNESCO cultural heritage list. Maracatu and Afoxê are two music traditions', 'page': 12.0, 'source': 'brazil-wikipedia-article-text.pdf'}\n",
       "{'text': 'music referred to as capoeira music, which is usually considered to be a call-and-response type of folk music. Forró is a\\ntype of folk music prominent during the Festa Junina in northeastern Brazil. Jack A. Draper III, a professor of Portuguese at\\nthe University of Missouri, argues that Forró was used as a way to subdue feelings of nostalgia for a rural lifestyle.', 'page': 13.0, 'source': 'brazil-wikipedia-article-text.pdf'}\n",
-      "{'text': 'characterized by traditional Portuguese festivities,\\nReligious pluralism increased during the 20th century, and the Protestant community has grown to include over 22% of the\\npopulation. The most common Protestant denominations are Evangelical Pentecostal ones. Other Protestant branches with', 'page': 10.0, 'source': 'brazil-wikipedia-article-text.pdf'}\n",
       "{'text': 'language, cuisine, music, dance and religion.\\nBrazilian art has developed since the 16th century into different styles that range from Baroque (the dominant style in Brazil\\nuntil the early 19th century) to Romanticism, Modernism, Expressionism, Cubism, Surrealism and Abstractionism. Brazilian', 'page': 12.0, 'source': 'brazil-wikipedia-article-text.pdf'}\n",
-      "{'text': 'The pottery was found near Santarém and provides evidence that the region supported a complex prehistoric culture. The\\nMarajoara culture flourished on Marajó in the Amazon delta from AD 400 to 1400, developing sophisticated pottery, social\\nstratification, large populations, mound building, and complex social formations such as chiefdoms.', 'page': 1.0, 'source': 'brazil-wikipedia-article-text.pdf'}\n"
+      "{'text': 'characterized by traditional Portuguese festivities,\\nReligious pluralism increased during the 20th century, and the Protestant community has grown to include over 22% of the\\npopulation. The most common Protestant denominations are Evangelical Pentecostal ones. Other Protestant branches with', 'page': 10.0, 'source': 'brazil-wikipedia-article-text.pdf'}\n",
+      "{'text': \"chicken meat, soybean meal, sugar, coffee, tobacco, cotton, orange juice, footwear, airplanes, cars, vehicle parts, gold,\\nethanol, semi-finished iron, among other products.\\nBrazil is the world's 24th-largest exporter and 26th-largest importer as of 2021. China is its largest trading partner,\", 'page': 7.0, 'source': 'brazil-wikipedia-article-text.pdf'}\n"
      ]
     }
    ],
@@ -419,7 +413,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -455,7 +449,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -497,7 +491,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -514,7 +508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -541,7 +535,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -570,80 +564,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from langchain.prompts import PromptTemplate\n",
-    "\n",
-    "prompt_template = \"\"\"Text: {context}\n",
-    "\n",
-    "Question: {question}\n",
-    "\n",
-    "Answer the question based on the text provided. If the text doesn't contain the answer, reply that the answer is not available.\"\"\"\n",
-    "\n",
-    "\n",
-    "PROMPT = PromptTemplate(\n",
-    "    template=prompt_template, input_variables=[\"context\", \"question\"]\n",
-    ")\n",
-    "\n",
-    "chain_type_kwargs = {\"prompt\": PROMPT}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/dudanogueira/dev/weaviate/recipes/.venv/lib/python3.12/site-packages/pydantic/main.py:1042: PydanticDeprecatedSince20: The `__fields__` attribute is deprecated, use `model_fields` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.7/migration/\n",
-      "  warnings.warn(\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'query': 'What is the traditional food of this country?', 'result': '\\n\\nThe traditional food of this country includes pastries such as Vlaai, Moorkop, and Bossche Bol, as well as savory pastries like worstenbroodje. Local beer is also a popular beverage.', 'source_documents': [Document(metadata={'page': 14.0, 'source': 'netherlands-wikipedia-article-text.pdf'}, page_content='cream, custard or fruits. Cakes, such as the \\nVlaai\\n from Limburg and the \\nMoorkop\\n and \\nBossche Bol\\n from Brabant, are typical\\npastries. Savoury pastries also occur, with the \\nworstenbroodje\\n (a roll with a sausage of ground beef, literally translates into sausage\\nbread) being the most popular. The traditional alcoholic beverage of the region is beer. There are many local brands, ranging from'), Document(metadata={'page': 14.0, 'source': 'netherlands-wikipedia-article-text.pdf'}, page_content='widely available and typical for the region. \\nKibbeling\\n, once a local delicacy consisting of small chunks of battered white fish, has\\nbecome a national fast food, just as lekkerbek.\\nThe Southern Dutch cuisine consists of the cuisines of the Dutch provinces of North Brabant and Limburg and the Flemish Region in'), Document(metadata={'page': 14.0, 'source': 'netherlands-wikipedia-article-text.pdf'}, page_content='(in its modern form) and \\nZeeuwse bolus\\n are\\ngood examples. Cookies are also produced in great number and tend to contain a lot of butter and sugar, like \\nstroopwafel\\n, as well\\nas a filling of some kind, mostly almond, like \\ngevulde koek\\n. The traditional alcoholic beverages of this region are beer (strong pale\\nlager) and \\nJenever'), Document(metadata={'page': 14.0, 'source': 'netherlands-wikipedia-article-text.pdf'}, page_content='Trappist\\n to \\nKriek\\n. 5 of the 10 \\nInternational Trappist Association\\n recognised breweries in the world, are located in the Southern Dutch\\ncultural area. Beer, like wine in French cuisine, is also used in cooking.\\nIn early 2014, Oxfam ranked the Netherlands as the country with the most nutritious, plentiful and healthy food.\\nSee also\\nOutline of the Netherlands\\nNotes\\nReferences\\nSources')]}\n"
+      "A traditional food of Brazil is Feijoada, which is considered the country's national dish. Other regional foods include beiju, feijão tropeiro, vatapá, and moqueca. Brazilian cuisine varies greatly by region, reflecting a mix of indigenous and immigrant influences.\n"
      ]
     }
    ],
    "source": [
-    "from langchain_openai import OpenAI\n",
-    "from langchain.chains import RetrievalQA\n",
+    "from langchain.chains import create_retrieval_chain\n",
+    "from langchain.chains.combine_documents import create_stuff_documents_chain\n",
+    "from langchain_core.prompts import ChatPromptTemplate\n",
+    "from langchain_openai import ChatOpenAI\n",
+    "from langchain_openai import OpenAIEmbeddings\n",
     "\n",
-    "# Let's answer some question\n",
-    "#source_file = \"brazil-wikipedia-article-text.pdf\"\n",
-    "source_file = \"netherlands-wikipedia-article-text.pdf\"\n",
-    "where_filter = wvc.query.Filter.by_property(\"source\").equal(source_file)\n",
+    "from weaviate.classes.query import Filter\n",
+    "\n",
+    "# client = weaviate.connect_to_weaviate_cloud(...)\n",
+    "\n",
+    "embeddings = OpenAIEmbeddings()\n",
+    "db = WeaviateVectorStore.from_documents([], embeddings, client=client, index_name=\"WikipediaLangChain\")\n",
+    "\n",
+    "source_file = \"brazil-wikipedia-article-text.pdf\"\n",
+    "#source_file = \"netherlands-wikipedia-article-text.pdf\"\n",
+    "where_filter = Filter.by_property(\"source\").equal(source_file)\n",
     "\n",
     "# we want our retriever to filter the results\n",
     "retriever = db.as_retriever(search_kwargs={\"filters\": where_filter})\n",
     "\n",
-    "qa = RetrievalQA.from_chain_type(llm=OpenAI(openai_api_key=os.environ.get(\"OPENAI_API_KEY\")),\n",
-    "                                 chain_type=\"stuff\", \n",
-    "                                 retriever=retriever, \n",
-    "                                 chain_type_kwargs=chain_type_kwargs, \n",
-    "                                 return_source_documents=True)\n",
-    "                                 \n",
-    "answer = qa({\"query\": \"What is the traditional food of this country?\"})\n",
-    "print(answer)"
+    "system_prompt = (\n",
+    "    \"You are an assistant for question-answering tasks. \"\n",
+    "    \"Use the following pieces of retrieved context to answer \"\n",
+    "    \"the question. If you don't know the answer, say that you \"\n",
+    "    \"don't know. Use three sentences maximum and keep the \"\n",
+    "    \"answer concise.\"\n",
+    "    \"\\n\\n\"\n",
+    "    \"{context}\"\n",
+    ")\n",
+    "\n",
+    "prompt = ChatPromptTemplate.from_messages(\n",
+    "    [\n",
+    "        (\"system\", system_prompt),\n",
+    "        (\"human\", \"{input}\"),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "llm = ChatOpenAI(model=\"gpt-4o-mini\")\n",
+    "question_answer_chain = create_stuff_documents_chain(llm, prompt)\n",
+    "rag_chain = create_retrieval_chain(retriever, question_answer_chain)\n",
+    "\n",
+    "response = rag_chain.invoke({\"input\": \"What is he traditional food of this country?\"})\n",
+    "print(response[\"answer\"])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "{\"action\":\"restapi_management\",\"level\":\"info\",\"msg\":\"Shutting down... \",\"time\":\"2024-04-17T10:30:07-03:00\"}\n",
-      "{\"action\":\"restapi_management\",\"level\":\"info\",\"msg\":\"Stopped serving weaviate at http://127.0.0.1:8079\",\"time\":\"2024-04-17T10:30:07-03:00\"}\n"
+      "{\"action\":\"restapi_management\",\"level\":\"info\",\"msg\":\"Shutting down... \",\"time\":\"2024-08-09T10:10:31-03:00\"}\n",
+      "{\"action\":\"restapi_management\",\"level\":\"info\",\"msg\":\"Stopped serving weaviate at http://127.0.0.1:8079\",\"time\":\"2024-08-09T10:10:31-03:00\"}\n"
      ]
     }
    ],


### PR DESCRIPTION


## Description 
<!-- A short description of the notebook -->
using [create_retrieval_chain](https://api.python.langchain.com/en/latest/chains/langchain.chains.retrieval.create_retrieval_chain.html#langchain-chains-retrieval-create-retrieval-chain) instead of [RetrievalQA](https://api.python.langchain.com/en/latest/chains/langchain.chains.retrieval_qa.base.RetrievalQA.html) in langchain example 

[followed by this discussion in forums](https://forum.weaviate.io/t/langchain-weaviatehybridsearchretriever-with-filters/3296/)
## Contribution Type
- [x] Integration
- [ ] Weaviate feature

## Promotion 
<!-- We'd love to promote your work on our socials! If you'd like to be featured, please complete the section below. -->
- X handle: 
- LinkedIn account: 
- Company `@` if applicable: 
