### PR TITLE
Adding Filtering to Weaviate Agents with Ollama

### DIFF
--- a/integrations/llm-frameworks/function-calling/ollama/Where-Filter-Function-Calling.ipynb
+++ b/integrations/llm-frameworks/function-calling/ollama/Where-Filter-Function-Calling.ipynb
@@ -1,0 +1,214 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "39630568",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import weaviate\n",
+    "\n",
+    "weaviate_client = weaviate.connect_to_local()\n",
+    "\n",
+    "knowledge_base = weaviate_client.collections.get(\"KnowledgeBase\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "c3c176e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from weaviate.classes.query import Filter\n",
+    "\n",
+    "def get_search_results(query: str, source: str) -> str:\n",
+    "    \"\"\"Sends a query to Weaviate's Hybrid Search. Parases the response into a {k}:{v} string.\"\"\"\n",
+    "    \n",
+    "    response = knowledge_base.query.hybrid(\n",
+    "        query,\n",
+    "        filters=Filter.by_property(\"_source\").equal(source),\n",
+    "        limit=3\n",
+    "    )\n",
+    "    \n",
+    "    stringified_response = \"\"\n",
+    "    for idx, o in enumerate(response.objects):\n",
+    "        stringified_response += f\"\\033[92mSearch Result: {idx+1}\\033[0m\\n\"\n",
+    "        for prop in o.properties:\n",
+    "            stringified_response += f\"{prop}: {o.properties[prop]}\"\n",
+    "        stringified_response += \"\\n\\n\"\n",
+    "    \n",
+    "    return stringified_response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "9f717d63",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[92mSearch Result: 1\u001b[0m\n",
+      "content: When we assign tasks to LMs in DSPy, we specify the behavior we need as a Signature.\n",
+      "\n",
+      "A signature is a declarative specification of input/output behavior of a DSPy module. Signatures allow you to tell the LM what it needs to do, rather than specify how we should ask the LM to do it.\n",
+      "\n",
+      "You're probably familiar with function signatures, which specify the input and output arguments and their types. DSPy signatures are similar, but the differences are that:\n",
+      "\n",
+      "- While typical function signatures just describe things, DSPy Signatures define and control the behavior of modules.\n",
+      "\n",
+      "- The field names matter in DSPy Signatures. You express semantic roles in plain English: a question is different from an answer, a sql_query is different from python_code._source: Docssummary: Introduction to DSPy Signatures, which specify the input/output behavior of a DSPy module, allowing you to tell the LM what it needs to do. Unlike typical function signatures, DSPy Signatures define and control module behavior, with field names expressing semantic roles.\n",
+      "\n",
+      "\u001b[92mSearch Result: 2\u001b[0m\n",
+      "content: Why should I use a DSPy Signature?\n",
+      "\n",
+      "**tl;dr** For modular and clean code, in which LM calls can be optimized into high-quality prompts (or automatic finetunes).\n",
+      "\n",
+      "**Long Answer:** Most people coerce LMs to do tasks by hacking long, brittle prompts. Or by collecting/generating data for fine-tuning.\n",
+      "\n",
+      "Writing signatures is far more modular, adaptive, and reproducible than hacking at prompts or finetunes. The DSPy compiler will figure out how to build a highly-optimized prompt for your LM (or finetune your small LM) for your signature, on your data, and within your pipeline. In many cases, we found that compiling leads to better prompts than humans write. Not because DSPy optimizers are more creative than humans, but simply because they can try more things and tune the metrics directly._source: Docssummary: Explanation of why to use DSPy Signatures: they provide modular, adaptive, and reproducible ways to optimize LM calls into high-quality prompts or finetunes, avoiding the need for brittle prompt hacking or extensive data collection.\n",
+      "\n",
+      "\u001b[92mSearch Result: 3\u001b[0m\n",
+      "content: #### `_prepare_signature() -> dspy.Signature`\n",
+      "\n",
+      "Prepares and returns a modified version of the signature associated with the TypedPredictor instance. This method iterates over the signature's fields to add format and parser functions based on their type annotations.\n",
+      "\n",
+      "**Returns:** A dspy.Signature object that has been enhanced with formatting and parsing specifications for its fields._source: Docssummary: Details about the `_prepare_signature` method, which prepares and returns a modified version of the signature with added formatting and parsing functions.\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(get_search_results(\"What is a DSPy Signature?\", source=\"Docs\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "5df3d951",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ollama\n",
+    "from typing import List, Dict\n",
+    "\n",
+    "tools_schema=[{\n",
+    "    'type': 'function',\n",
+    "    'function': {\n",
+    "        'name': 'get_search_results',\n",
+    "        'description': 'Get search results for a provided query.',\n",
+    "        'parameters': {\n",
+    "          'type': 'object',\n",
+    "          'properties': {\n",
+    "            'query': {\n",
+    "                'type': 'string',\n",
+    "                'description': 'The search query.',\n",
+    "            },\n",
+    "            'source': {\n",
+    "                'type': 'string',\n",
+    "                'description': 'The source to search through, either \"DOCS\" or \"CODE\"' \n",
+    "            },\n",
+    "          }\n",
+    "        },\n",
+    "        'required': ['query'],\n",
+    "    },\n",
+    "}]\n",
+    "\n",
+    "tool_mapping = {\n",
+    "    \"get_search_results\": get_search_results\n",
+    "}\n",
+    "\n",
+    "def ollama_generation_with_tools(user_message: str,\n",
+    "                                 tools_schema: List, tool_mapping: Dict,\n",
+    "                                 model_name: str = \"llama3.1\") -> str:\n",
+    "    messages=[{\n",
+    "        \"role\": \"user\",\n",
+    "        \"content\": user_message\n",
+    "    }]\n",
+    "    response = ollama.chat(\n",
+    "        model=model_name,\n",
+    "        messages=messages,\n",
+    "        tools=tools_schema\n",
+    "    )\n",
+    "    if not response[\"message\"].get(\"tool_calls\"):\n",
+    "        return response[\"message\"][\"content\"]\n",
+    "    else:\n",
+    "        for tool in response[\"message\"][\"tool_calls\"]:\n",
+    "            function_to_call = tool_mapping[tool[\"function\"][\"name\"]]\n",
+    "            print(f\"Calling function {function_to_call}...\")\n",
+    "            query = tool[\"function\"][\"arguments\"][\"query\"]\n",
+    "            source = tool[\"function\"][\"arguments\"][\"source\"]\n",
+    "            print(f\"With args\\n\\tquery={query}\\n\\tsource={source}\")\n",
+    "            function_response = function_to_call(\n",
+    "                query=query,\n",
+    "                source=source\n",
+    "            )\n",
+    "            messages.append({\n",
+    "                \"role\": \"tool\",\n",
+    "                \"content\": function_response,\n",
+    "            })\n",
+    "    \n",
+    "    final_response = ollama.chat(model=model_name, messages=messages)\n",
+    "    return final_response[\"message\"][\"content\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "c0aa6b05",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Calling function <function get_search_results at 0x120f0dcf0>...\n",
+      "With args\n",
+      "\tquery=WeaviateRM\n",
+      "\tsource=DOCS\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'The WeaviateRM (Retriever Module) is a component of the Weaviate library that enables similarity-based retrieval of data points from an in-memory vector database. It uses the Faiss (Facebook AI Similarity Search) algorithm to efficiently search for similar vectors.\\n\\nIn the context of the provided code snippets, WeaviateRM is used as part of the DSPy (Data Science Python) framework to create a retriever that can be used with various sentence embedding models, such as those provided by SentenceTransformersVectorizer. This allows for efficient retrieval of similar sentences based on their embeddings.\\n\\nTo use WeaviateRM, you would typically:\\n\\n1. Import the necessary libraries and modules.\\n2. Create an instance of the WeaviateRM class, passing in a list of document chunks (sentences) to be indexed.\\n3. Configure the settings to specify the retriever module (in this case, WeaviateRM).\\n4. Perform search queries by calling methods on the WeaviateRM instance.\\n\\nNote that WeaviateRM is designed for use with sentence embedding models, and it does not include a vectorizer itself; instead, it relies on any subclass of dsp.modules.sentence_vectorizer.BaseSentenceVectorizer to generate the embeddings for the documents being indexed.'"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ollama_generation_with_tools(\"What is the WeaviateRM?\",\n",
+    "                            tools_schema=tools_schema, tool_mapping=tool_mapping)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "weaviate-agents",
+   "language": "python",
+   "name": "weaviate-agents"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This notebook illustrates how to use Weaviate's `Where` Filter syntax with Ollama Function Calling. This lets Agents select symbolic features to their searches such as `date` or `source`. More to come!