### PR TITLE
Fix broken Colab link

### DIFF
--- a/integrations/data-platforms/ibm/docling/rag_over_pdfs_docling_weaviate.ipynb
+++ b/integrations/data-platforms/ibm/docling/rag_over_pdfs_docling_weaviate.ipynb
@@ -8,7 +8,7 @@
       "source": [
         "# Performing RAG over PDFs with Weaviate and Docling\n",
         "## A recipe 🧑‍🍳 🐥 💚\n",
-        "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/your-username/your-repo/blob/main/notebook.ipynb)\n",
+        "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/weaviate/recipes/blob/main/integrations/data-platforms/ibm/docling/rag_over_pdfs_docling_weaviate.ipynb)\n",
         "\n",
         "By Mary Newhauser, MLE @ Weaviate\n",
         "\n",


### PR DESCRIPTION
Fix broke "Open in Colab" link in Docling notebook.
