### PR TITLE
adding the llama index weaviate assistant agent

### DIFF
--- a/integrations/llm-frameworks/llamaindex/agents/llama-index-weaviate-assistant-agent.ipynb
+++ b/integrations/llm-frameworks/llamaindex/agents/llama-index-weaviate-assistant-agent.ipynb
@@ -1,0 +1,660 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Agent vs No Agent\n",
+    "\n",
+    "by Tuana Celik [🦋 Bsky](https://bsky.app/profile/tuana.dev), [LI](https://www.linkedin.com/in/tuanacelik/), [X](https://x.com/tuanacelik)\n",
+    "\n",
+    "This recipe walks you through the difference between naive RAG, and an agent that has RAG tools. \n",
+    "\n",
+    "In this example notebook, we are using 2 Weaviate collections:\n",
+    "\n",
+    "1. **Weaviate Docs:** This collection contains the technical documentation that you can find on weaviate.io. We've already created embeddings for them using `embed-multilingual-v3.0` by Cohere.\n",
+    "2. **GitHub Issues:** A collection which contains some of the GitHub issues on Weaviate Verba.\n",
+    "\n",
+    "**To replicate the behaviour, you may choose to create and use 2 of your own Weavaite collections.**\n",
+    "If you choose to do so, don't forget to change the RAG tools accordingly.\n",
+    "\n",
+    "We will see how providing these 2 collections and RAG over these collections as tools to an agent changes the way we are able to interact with them.\n",
+    "\n",
+    "### First: Installations & Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install weaviate-client python-dotenv llama-index llama-index-vector-stores-weaviate llama-index-embeddings-openai llama-index-embeddings-cohere"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import weaviate\n",
+    "from weaviate.classes.init import Auth\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "\n",
+    "from llama_index.vector_stores.weaviate import WeaviateVectorStore\n",
+    "from llama_index.core import VectorStoreIndex\n",
+    "from llama_index.core.response.pprint_utils import pprint_source_node\n",
+    "from llama_index.llms.openai import OpenAI\n",
+    "from llama_index.core import PromptTemplate\n",
+    "from llama_index.core.query_engine import CustomQueryEngine\n",
+    "from llama_index.core.retrievers import BaseRetriever\n",
+    "from llama_index.core import get_response_synthesizer\n",
+    "from llama_index.core.response_synthesizers import BaseSynthesizer\n",
+    "from llama_index.embeddings.openai import OpenAIEmbedding\n",
+    "from llama_index.embeddings.cohere import CohereEmbedding\n",
+    "\n",
+    "\n",
+    "load_dotenv()\n",
+    "\n",
+    "headers = {\"X-OpenAI-Api-Key\": os.getenv(\"OPENAI_APIKEY\")}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Discover the Collections\n",
+    "1. GitHub Issues Collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 235,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weaviate_issues_url = os.environ[\"WEAVIATE_ISSUES_URL\"]\n",
+    "weaviate_issues_api_key = os.environ[\"WEAVIATE_ISSUES_KEY\"]\n",
+    "\n",
+    "issues_client = weaviate.connect_to_weaviate_cloud(\n",
+    "    cluster_url=weaviate_issues_url,\n",
+    "    auth_credentials=Auth.api_key(weaviate_issues_api_key),\n",
+    "    headers=headers\n",
+    ")\n",
+    "\n",
+    "issues = issues_client.collections.get(name=\"example_verba_github_issues\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 215,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'issue_id': 2306015626.0,\n",
+       " 'issue_content': 'Adds OLLAMA_EMBED_MODEL environment variable\\r\\nSet this to an ollama model that supports\\r\\nembeddings like mxbai-embed-large\\r\\nSolves #171\\r',\n",
+       " 'issue_url': 'https://github.com/weaviate/Verba/pull/178',\n",
+       " 'issue_labels': [],\n",
+       " 'issue_comments': 1.0,\n",
+       " 'issue_created_at': datetime.datetime(2024, 5, 20, 13, 33, 38, tzinfo=datetime.timezone.utc),\n",
+       " 'issue_title': 'Adds OLLAMA_EMBED_MODEL env variable',\n",
+       " 'issue_author': 'kjeldahl',\n",
+       " 'issue_updated_at': datetime.datetime(2024, 5, 27, 11, 25, 17, tzinfo=datetime.timezone.utc),\n",
+       " 'issue_state': 'closed'}"
+      ]
+     },
+     "execution_count": 215,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "next(issues.iterator()).properties"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "2. Weaviate Documentation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 236,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weaviate_url = os.environ[\"WEAVIATE_DOCS_URL\"]\n",
+    "weaviate_api_key = os.environ[\"WEAVIATE_API_KEY\"]\n",
+    "\n",
+    "client = weaviate.connect_to_weaviate_cloud(\n",
+    "    cluster_url=weaviate_url,\n",
+    "    auth_credentials=Auth.api_key(weaviate_api_key),\n",
+    "    headers=headers\n",
+    ")\n",
+    "\n",
+    "docs = client.collections.get(name=\"PageChunk\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 217,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'content': 'The list of metrics that are obtainable through Weaviate\\'s metric system is constantly being expanded. The complete list is in the prometheus.go source code file. This page describes some noteworthy metrics and their uses. Typically metrics are quite granular, as they can always be aggregated later on. For example if the granularity is \"shard\", you could aggregate all \"shard\" metrics of the same \"class\" to obtain a class metrics, or aggregate all metrics to obtain the metric for the entire Weaviate instance. | Metric | Description | Labels | Type | | --- | --- | --- | --- | | batch_durations_ms | Duration of a single batch operation in ms. The operation label further defines what operation as part of the batch (e.g. object, inverted, vector) is being used. Granularity is a shard of a class.  | operation, class_name, shard_name | Histogram | | batch_delete_durations_ms | Duration of a batch delete in ms. The operation label further defines what operation as part of the batch delete is being measured. Granularity is a shard of a class | class_name, shard_name | Histogram | | objects_durations_ms | Duration of an individual object operation, such as put, delete, etc. as indicated by the operation label, also as part of a batch. The step label adds additional precisions to each operation. Granularity is a shard of a class. | class_name, shard_name | Histogram | | object_count | Numbers of objects present. Granularity is a shard of a class | class_name, shard_name | Gauge | | async_operations_running | Number of currently running async operations. The operation itself is defined through the operation label. | operation, class_name, shard_name, path | Gauge | | lsm_active_segments | Number of currently present segments per shard. Granularity is shard of a class. Grouped by strategy.| strategy, class_name, shard_name, path | Gauge | | lsm_bloom_filter_duration_ms | Duration of a bloom filter operation per shard in ms. Granularity is shard of a class. Grouped by strategy. | operation, strategy, class_name, shard_name | Histogram | | lsm_segment_objects | Number of entries per LSM segment by level. Granularity is shard of a class. Grouped by strategy and level. | operation, strategy, class_name, shard_name, path, level | Gauge | | lsm_segment_size | Size of LSM segment by level and unit. | strategy, class_name, shard_name, path, level, unit | Gauge | | lsm_segment_count | Number of segments by level | strategy, class_name, shard_name, path, level | Gauge | | vector_index_tombstones | Number of currently active tombstones in the vector index. Will go up on each incoming delete and go down after a completed repair operation. | class_name, shard_name  | Gauge | | vector_index_tombstone_cleanup_threads | Number of currently active threads for repairing/cleaning up the vector index after deletes have occurred. | class_name, shard_name  | Gauge | | vector_index_tombstone_cleaned | Total number of deleted and removed vectors after repair operations. | class_name, shard_name  | Counter | | vector_index_operations | Total number of mutating operations on the vector index. The operation itself is defined by the operation label. | operation, class_name, shard_name | Gauge | | vector_index_size | The total capacity of the vector index. Typically larger than the number of vectors imported as it grows proactively. | class_name, shard_name | Gauge | | vector_index_maintenance_durations_ms | Duration of a sync or async vector index maintenance operation. The operation itself is defined through the operation label. | opeartion, class_name, shard_name | Histogram | | vector_index_durations_ms | Duration of regular vector index operation, such as insert or delete. The operation itself is defined through the operation label. The step label adds more granularity to each operation. | operation, step, class_name, shard_name | Histogram | | startup_durations_ms | Duration of individual startup operations in ms. The operation itself is defined through the operation label. | operation, class_name, shard_name | Histogram | | startup_diskio_throughput | Disk I/O throughput in bytes/s at startup operations, such as reading back the HNSW index or recovering LSM segments. The operation itself is defined by the operation label. | operation, step, class_name, shard_name | Histogram | | requests_total | Metric that tracks all user requests to determine if it was successful or failed. | api, query_type, class_name | GaugeVec | | index_queue_push_duration_ms | Duration of pushing one or more vectors to the index queue. | class_name, shard_name, target_vector | Summary | | index_queue_delete_duration_ms | Duration of deleting one or more vectors from the index queue and the underlying index. | class_name, shard_name, target_vector | Summary | | index_queue_preload_duration_ms | Duration of preloading un-indexed vectors to the index queue. | class_name, shard_name, target_vector | Summary | | index_queue_preload_count | Number of vectors preloaded to the index queue. | class_name, shard_name, target_vector | Gauge | | index_queue_search_duration_ms | Duration of searching for vectors in the index queue and the underlying index. | class_name, shard_name, target_vector | Summary | | index_queue_paused | Whether the index queue is paused. | class_name, shard_name, target_vector | Gauge | | index_queue_size | Number of vectors in the index queue. | class_name, shard_name, target_vector | Gauge | | index_queue_stale_count | Number of times the index queue has been marked as stale. | class_name, shard_name, target_vector | Counter | | index_queue_vectors_dequeued | Number of vectors sent to the workers per tick. | class_name, shard_name, target_vector | Gauge | | index_queue_wait_duration_ms | Duration of waiting for the workers to finish. | class_name, shard_name, target_vector | Summary | Extending Weaviate with new metrics is very easy. To suggest a new metric, see the contributor guide.',\n",
+       " 'typeOfItem': 'docs',\n",
+       " 'url': '/developers/weaviate/configuration/monitoring',\n",
+       " 'pageTitle': 'Monitoring',\n",
+       " 'title': 'Obtainable Metrics',\n",
+       " 'anchor': 'obtainable-metrics',\n",
+       " 'order': 7}"
+      ]
+     },
+     "execution_count": 217,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "next(docs.iterator()).properties"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Query the Resources\n",
+    "\n",
+    "Let's say we're trying to find out something about Weaviate. For example: \"Can I use Ollama for to generate answers?\"\n",
+    "\n",
+    "Observations:\n",
+    "- This questin probably makes sense to ask the `docs` collection 👇"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 218,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "===============================\n",
+      "Finally, you can use Ollama’s generate() method to generate a response from the augmented prompt template. # Generate a response combining the prompt and data we retrieved in step 2 output = ollama.generate(   model = \"llama2\",   prompt = prompt_template, )  print(output['response'])  Llamas are members of the camelid family, which means they are closely related to other animals in the same family, including: 1. Vicuñas: Vicuñas are small, wild relatives of llamas and alpacas. They are found in the Andean region and are known for their soft, woolly coats. 2. Camels: Camels are large, even-toed ungulates that are closely related to llamas and vicuñas. They are found in hot, dry climates around the world and are known for their ability to go without water for long periods of time. 3. Guanacos: Guanacos are large, wild animals that are related to llamas and vicuñas. They are found in the Andean region and are known for their distinctive long necks and legs. 4. Llama-like creatures: There are also other animals that are sometimes referred to as \"llamas,\" such as the lama-like creatures found in China, which are actually a different species altogether. These creatures are not closely related to vicuñas or camels, but are sometimes referred to as \"llamas\" due to their physical similarities. In summary, llamas are related to vicuñas, camels, guanacos, and other animals that are sometimes referred to as \"llamas.\"\n",
+      "https://weaviate.io/blog/local-rag-with-ollama-and-weaviate\n",
+      "===============================\n",
+      "Ollama's generative AI models can generate human-like text based on given prompts and contexts. Weaviate's generative AI integration enables users to perform retrieval augmented generation (RAG) directly within the Weaviate database. This combines Weaviate's efficient storage and fast retrieval capabilities with Ollama's generative AI models to generate personalized and context-aware responses. Ollama generative AI integration page\n",
+      "https://weaviate.io/developers/weaviate/model-providers/ollama\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = docs.query.near_text(\n",
+    "    query=\"Can I use Ollama for to generate answers?\",\n",
+    "    return_properties=[\"content\", \"url\"],\n",
+    "    limit=2)\n",
+    "\n",
+    "for doc in response.objects:\n",
+    "    print(\"===============================\")\n",
+    "    print(doc.properties[\"content\"])\n",
+    "    print(\"https://weaviate.io\"+doc.properties[\"url\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now assume we want to find out wheter there have been any reports of certain issues. For example: \"Has anyone reported weaviate issues about Ollama?\"\n",
+    "\n",
+    "Observations:\n",
+    "- This questin probably makes sense to ask the `issues` collection 👇"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 219,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "===============================\n",
+      "![500 Internal Server Error](https://github.com/weaviate/Verba/assets/72214141/f97581dd-f4c5-4c13-be54-3ff7f3926735)\n",
+      "I using ollama docker and found this issues :(\n",
+      "https://github.com/weaviate/Verba/issues/134\n",
+      "===============================\n",
+      "## Description\n",
+      "Hey everyone,\n",
+      "I just cloned Verba locally and set the environment variables. I want to use Ollama for Embedding and Generation (using Llama3) but I cannot see where to choose the Ollama generator model from the settings after running my Verba instance.\n",
+      "Ollama is running at http://localhost:11434\n",
+      "Did anyone have the same problem? Please let me know what I missed.\n",
+      "Thanks!\n",
+      "## Is this a bug or a feature?\n",
+      "Bug\n",
+      "https://github.com/weaviate/Verba/issues/156\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = issues.query.near_text(\n",
+    "    query=\"Has anyone reported weaviate issues about Ollama?\",\n",
+    "    return_properties=[\"issue_content\", \"issue_url\"],\n",
+    "    target_vector=\"issue_content\",\n",
+    "    limit=2)\n",
+    "\n",
+    "for issue in response.objects:\n",
+    "    print(\"===============================\")\n",
+    "    print(issue.properties[\"issue_content\"])\n",
+    "    print(issue.properties[\"issue_url\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Do RAG on Resources\n",
+    "\n",
+    "Let's try the question: \"How can I use generative models with Ollama and weaviate and are there any known issues about this feature?\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "docs_vector_store = WeaviateVectorStore(\n",
+    "    weaviate_client=client, index_name=\"PageChunk\", text_key=\"content\"\n",
+    ")\n",
+    "\n",
+    "docs_retriever = VectorStoreIndex.from_vector_store(vector_store=docs_vector_store).as_retriever(\n",
+    "    similarity_top_k=10,\n",
+    "    embed_model=CohereEmbedding(model_name=\"embed-multilingual-v3.0\", api_key=os.environ['COHERE_APIKEY'])\n",
+    ")\n",
+    "\n",
+    "class WeaviateDocsRAG(CustomQueryEngine):\n",
+    "    retriever: BaseRetriever\n",
+    "    response_synthesizer: BaseSynthesizer\n",
+    "    llm: OpenAI\n",
+    "    docs_qa_with_references_prompt: PromptTemplate\n",
+    "    docs_qa_with_references_prompt = PromptTemplate(\n",
+    "\"\"\"Below is the relevant cotent, followed by the URL that they are referenced from\n",
+    "---------------------\n",
+    "{docs_and_url}\\n\n",
+    "---------------------\\n\n",
+    "Given the context information and not prior knowledge, \n",
+    "answer the query.\\n\"\n",
+    "Provide the reference(s) that the answer is generated from.\\n\n",
+    "Query: {query_str}\\n\n",
+    "Answer: \"\"\"\n",
+    ")\n",
+    "    def custom_query(self, query_str: str):\n",
+    "        nodes = self.retriever.retrieve(query_str)\n",
+    "\n",
+    "        context_and_references_str = \"\"\n",
+    "        for node in nodes:\n",
+    "            content = node.node.get_content()\n",
+    "            reference = \"https://weaviate.io\"+node.node.metadata['properties']['url']\n",
+    "            context_and_references_str += f\"\\nContent: {content}\\nURL:{reference}\"\n",
+    "        response = self.llm.complete(\n",
+    "            self.docs_qa_with_references_prompt.format(docs_and_url=context_and_references_str, query_str=query_str)\n",
+    "        )\n",
+    "\n",
+    "        return str(response)\n",
+    "\n",
+    "synthesizer = get_response_synthesizer(response_mode=\"compact\")\n",
+    "llm = OpenAI(model=\"gpt-4o-mini\")\n",
+    "\n",
+    "query_engine = WeaviateDocsRAG(\n",
+    "    retriever=docs_retriever,\n",
+    "    response_synthesizer=synthesizer,\n",
+    "    llm=llm,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 221,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "To use generative models with Ollama in Weaviate, you need to follow these steps:\n",
+      "\n",
+      "1. **Set Up a Locally Hosted Weaviate Instance**: Ensure that you have a locally hosted Weaviate instance, as the integration requires hosting your own Ollama models. You can find guidance on configuring Weaviate with Ollama models on the relevant integration page.\n",
+      "\n",
+      "2. **Configure Weaviate with the Ollama Generative AI Integration**: Your Weaviate instance must be configured with the `generative-ollama` module. This integration is not available for Weaviate Cloud (WCD) serverless instances, as it requires a locally running Ollama instance. For self-hosted users, check the cluster metadata to verify if the module is enabled and follow the guide to enable it.\n",
+      "\n",
+      "3. **Access the Ollama Endpoint**: Ensure that your Weaviate instance can access the Ollama endpoint. If you are using Docker, specify the Ollama endpoint using the `host.docker.internal` alias to access the host machine from within the container.\n",
+      "\n",
+      "4. **Download and Install Ollama**: Download and install Ollama for your operating system. Once installed, the Ollama daemon will run in the background, allowing you to use the `ollama` command in the shell or Terminal to download and pull a language model.\n",
+      "\n",
+      "5. **Pull a Language Model**: Use the command `ollama pull llama3:latest` to download the Llama 3:8B model to your local machine. After downloading, you can run the model using `ollama run llama3:latest`.\n",
+      "\n",
+      "6. **Use the Model for Inference**: Once the model is set up, you can perform inference through the API provided by Ollama, similar to how you would with OpenAI.\n",
+      "\n",
+      "For detailed instructions and configurations, refer to the following references:\n",
+      "\n",
+      "- [Weaviate's integration with Ollama's models](https://weaviate.io/developers/weaviate/model-providers/ollama/generative)\n",
+      "- [Ollama generative AI integration page](https://weaviate.io/developers/weaviate/model-providers/ollama)\n",
+      "- [How to configure modules in Weaviate](https://weaviate.io/developers/weaviate/model-providers/ollama/generative)\n",
+      "- [Verba with local LLM](https://weaviate.io/blog/2024-07-09-verba-with-local-llm)\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = query_engine.query(\"How can I use use generative models with Ollama with weaviate?\")\n",
+    "\n",
+    "print(str(response))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 238,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "issues_vector_store = WeaviateVectorStore(\n",
+    "    weaviate_client=issues_client, index_name=\"Example_verba_github_issues\", text_key=\"issue_content\"\n",
+    ")\n",
+    "\n",
+    "issues_retriever = VectorStoreIndex.from_vector_store(vector_store=issues_vector_store).as_retriever(\n",
+    "    similarity_top_k=10,\n",
+    "    embed_model=OpenAIEmbedding(model_name=\"text-embedding-ada-002\", api_key=os.environ['OPENAI_APIKEY'])\n",
+    ")\n",
+    "\n",
+    "class WeaviateIssuesRAG(CustomQueryEngine):\n",
+    "    retriever: BaseRetriever\n",
+    "    response_synthesizer: BaseSynthesizer\n",
+    "    llm: OpenAI\n",
+    "    issues_prompt: PromptTemplate\n",
+    "    issues_prompt = PromptTemplate(\n",
+    "\"\"\"Below are the relevant GitHub issues, followed by their URL and status\n",
+    "---------------------\n",
+    "{issues}\\n\n",
+    "---------------------\\n\n",
+    "Given the content of the issues information and not prior knowledge, \n",
+    "answer the query.\\n\"\n",
+    "Provide the reference(s) that the answer is generated from.\\n\n",
+    "Query: {query_str}\\n\n",
+    "Answer: \"\"\"\n",
+    ")\n",
+    "    def custom_query(self, query_str: str):\n",
+    "        nodes = self.retriever.retrieve(query_str)\n",
+    "\n",
+    "        context_and_references_str = \"\"\n",
+    "        for node in nodes:\n",
+    "            content = node.node.get_content()\n",
+    "            reference = node.node.metadata['properties']['issue_url']\n",
+    "            status = node.node.metadata['properties']['issue_state']\n",
+    "            context_and_references_str += f\"\\nContent: {content}\\nURL:{reference}\\nSTATUS:{status}\"\n",
+    "        response = self.llm.complete(\n",
+    "            self.issues_prompt.format(issues=context_and_references_str, query_str=query_str)\n",
+    "        )\n",
+    "\n",
+    "        return str(response)\n",
+    "\n",
+    "synthesizer = get_response_synthesizer(response_mode=\"compact\")\n",
+    "llm = OpenAI(model=\"gpt-4o-mini\")\n",
+    "\n",
+    "issues_query_engine = WeaviateIssuesRAG(\n",
+    "    retriever=issues_retriever,\n",
+    "    response_synthesizer=synthesizer,\n",
+    "    llm=llm,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 223,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Based on the provided information, there are no open issues regarding the use of Ollama models. All the listed issues and pull requests related to Ollama have a status of \"closed.\" \n",
+      "\n",
+      "References:\n",
+      "- https://github.com/weaviate/Verba/issues/81 (closed)\n",
+      "- https://github.com/weaviate/Verba/issues/19 (closed)\n",
+      "- https://github.com/weaviate/Verba/issues/156 (closed)\n",
+      "- https://github.com/weaviate/Verba/issues/209 (closed)\n",
+      "- https://github.com/weaviate/Verba/issues/218 (closed)\n",
+      "- https://github.com/weaviate/Verba/issues/161 (closed)\n",
+      "- https://github.com/weaviate/Verba/issues/12 (closed)\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = issues_query_engine.query(\"Are there any known open about using Ollama models?\")\n",
+    "\n",
+    "print(str(response))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a Weaviate Assistant Agent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 239,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llama_index.core.tools import QueryEngineTool, ToolMetadata\n",
+    "from llama_index.agent.openai import OpenAIAgent\n",
+    "from llama_index.core.tools import QueryPlanTool\n",
+    "\n",
+    "query_engine_tools = [\n",
+    "    QueryEngineTool(\n",
+    "        query_engine=query_engine,\n",
+    "        metadata=ToolMetadata(\n",
+    "            name=\"weaviate_docs\",\n",
+    "            description=\"Technical documentation for Weaviate useful for answering general questions about weaviate.\",\n",
+    "        ),\n",
+    "    ),\n",
+    "    QueryEngineTool(\n",
+    "        query_engine=issues_query_engine,\n",
+    "        metadata=ToolMetadata(\n",
+    "            name=\"weaviate_github_issues\",\n",
+    "            description=\"A list of GitHub issues and pull requests for weaviate. Useful to refer to ongoing, known issues or upcoming features\",\n",
+    "        ),\n",
+    "    ),\n",
+    "]\n",
+    "\n",
+    "agent = OpenAIAgent.from_tools(query_engine_tools,\n",
+    "                               max_function_calls=10, \n",
+    "                               llm=OpenAI(model=\"gpt-4o-mini\"), verbose=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 242,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Added user message to memory: Tell me how I can use Ollama models and let me know if there are any issues I should know of.\n",
+      "=== Calling Function ===\n",
+      "Calling function: weaviate_docs with args: {\"input\": \"How to use Ollama models?\"}\n",
+      "Got output: To use Ollama models, you need to follow these steps:\n",
+      "\n",
+      "1. **Install Ollama**: First, download and install Ollama for your operating system. This will set up a web server on your machine for inference through an API.\n",
+      "\n",
+      "2. **Pull Models**: Open a terminal and use the `ollama pull <model-name>` command to download the desired models. For example, you can pull the Llama 3 model with the command:\n",
+      "   ```\n",
+      "   ollama pull llama3:latest\n",
+      "   ```\n",
+      "   You can also pull embedding models, such as:\n",
+      "   ```\n",
+      "   ollama pull snowflake-arctic-embed\n",
+      "   ```\n",
+      "\n",
+      "3. **Run Models**: Once the models are downloaded, you can run them using the command:\n",
+      "   ```\n",
+      "   ollama run <model-name>\n",
+      "   ```\n",
+      "\n",
+      "4. **Integrate with Weaviate**: If you are using Weaviate, you can configure it to use Ollama's generative or embedding models for retrieval-augmented generation (RAG) or vectorization. This involves setting up a Weaviate collection or vector index to utilize the models via your local Ollama instance.\n",
+      "\n",
+      "5. **Docker Setup**: If you want to run Ollama and Weaviate locally, you may also need to build the Ollama image using Docker and ensure that the relevant models are pulled and ready to be served.\n",
+      "\n",
+      "References:\n",
+      "- [Ollama Generative Models Documentation](https://weaviate.io/developers/weaviate/model-providers/ollama/generative)\n",
+      "- [Ollama Embedding Models Documentation](https://weaviate.io/developers/weaviate/model-providers/ollama/embeddings)\n",
+      "- [Verba with Local LLM](https://weaviate.io/blog/2024-07-09-verba-with-local-llm)\n",
+      "- [Local RAG with Ollama and Weaviate](https://weaviate.io/blog/local-rag-with-ollama-and-weaviate)\n",
+      "- [Weaviate Quickstart](https://weaviate.io/developers/weaviate/quickstart/local)\n",
+      "========================\n",
+      "\n",
+      "=== Calling Function ===\n",
+      "Calling function: weaviate_github_issues with args: {\"input\": \"Ollama models\"}\n",
+      "Got output: The references related to Ollama models from the provided GitHub issues are as follows:\n",
+      "\n",
+      "1. **Issue #81**: Discusses the desire to use a local Ollama endpoint for hosting models rather than relying on an external API or service. \n",
+      "   - URL: [Issue #81](https://github.com/weaviate/Verba/issues/81)\n",
+      "\n",
+      "2. **Pull Request #133**: Mentions the implementation of an Ollama generator to connect to the Ollama server with model compatibility for on-premise usage.\n",
+      "   - URL: [Pull Request #133](https://github.com/weaviate/Verba/pull/133)\n",
+      "\n",
+      "3. **Pull Request #178**: Introduces the `OLLAMA_EMBED_MODEL` environment variable for specifying an Ollama model that supports embeddings.\n",
+      "   - URL: [Pull Request #178](https://github.com/weaviate/Verba/pull/178)\n",
+      "\n",
+      "4. **Issue #209**: Describes a problem with vectorization using the `nomic-embed-text:latest` model and the need for specifying vector length.\n",
+      "   - URL: [Issue #209](https://github.com/weaviate/Verba/issues/209)\n",
+      "\n",
+      "5. **Issue #156**: A user expresses difficulty in selecting the Ollama generator model after setting environment variables for embedding and generation.\n",
+      "   - URL: [Issue #156](https://github.com/weaviate/Verba/issues/156)\n",
+      "\n",
+      "6. **Issue #218**: Inquires about using an Ollama installation on a different machine within the same local network.\n",
+      "   - URL: [Issue #218](https://github.com/weaviate/Verba/issues/218)\n",
+      "\n",
+      "7. **Issue #171**: Discusses issues with adding documents and getting responses when using specific Ollama models, highlighting the need for specifying both embedding and chat models.\n",
+      "   - URL: [Issue #171](https://github.com/weaviate/Verba/issues/171)\n",
+      "\n",
+      "These references provide insights into the usage, configuration, and issues related to Ollama models within the context of the Verba project.\n",
+      "========================\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = agent.chat(\"Tell me how I can use Ollama models and let me know if there are any issues I should know of.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 243,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "### How to Use Ollama Models\n",
+      "\n",
+      "1. **Install Ollama**: Download and install Ollama for your operating system. This will set up a web server on your machine for inference through an API.\n",
+      "\n",
+      "2. **Pull Models**: Open a terminal and use the `ollama pull <model-name>` command to download the desired models. For example, to pull the Llama 3 model, use:\n",
+      "   ```bash\n",
+      "   ollama pull llama3:latest\n",
+      "   ```\n",
+      "   You can also pull embedding models, such as:\n",
+      "   ```bash\n",
+      "   ollama pull snowflake-arctic-embed\n",
+      "   ```\n",
+      "\n",
+      "3. **Run Models**: Once the models are downloaded, you can run them using the command:\n",
+      "   ```bash\n",
+      "   ollama run <model-name>\n",
+      "   ```\n",
+      "\n",
+      "4. **Integrate with Weaviate**: If you are using Weaviate, configure it to use Ollama's generative or embedding models for retrieval-augmented generation (RAG) or vectorization. This involves setting up a Weaviate collection or vector index to utilize the models via your local Ollama instance.\n",
+      "\n",
+      "5. **Docker Setup**: If you want to run Ollama and Weaviate locally, you may also need to build the Ollama image using Docker and ensure that the relevant models are pulled and ready to be served.\n",
+      "\n",
+      "### Known Issues with Ollama Models\n",
+      "\n",
+      "1. **Local Endpoint Usage**: There is a desire among users to use a local Ollama endpoint for hosting models instead of relying on external APIs. [Issue #81](https://github.com/weaviate/Verba/issues/81) discusses this need.\n",
+      "\n",
+      "2. **Model Compatibility**: There are ongoing discussions about connecting to the Ollama server with model compatibility for on-premise usage, as mentioned in [Pull Request #133](https://github.com/weaviate/Verba/pull/133).\n",
+      "\n",
+      "3. **Environment Variables**: Users have reported difficulties in selecting the Ollama generator model after setting environment variables for embedding and generation. This is highlighted in [Issue #156](https://github.com/weaviate/Verba/issues/156).\n",
+      "\n",
+      "4. **Vectorization Issues**: There are problems with vectorization using specific models, such as the `nomic-embed-text:latest` model, which requires specifying vector length. This is discussed in [Issue #209](https://github.com/weaviate/Verba/issues/209).\n",
+      "\n",
+      "5. **Document Addition Errors**: Users have encountered issues with adding documents and getting responses when using specific Ollama models, as noted in [Issue #171](https://github.com/weaviate/Verba/issues/171).\n",
+      "\n",
+      "6. **Network Configuration**: There are inquiries about using an Ollama installation on a different machine within the same local network, as discussed in [Issue #218](https://github.com/weaviate/Verba/issues/218).\n",
+      "\n",
+      "### References\n",
+      "- [Ollama Generative Models Documentation](https://weaviate.io/developers/weaviate/model-providers/ollama/generative)\n",
+      "- [Ollama Embedding Models Documentation](https://weaviate.io/developers/weaviate/model-providers/ollama/embeddings)\n",
+      "- [Verba with Local LLM](https://weaviate.io/blog/2024-07-09-verba-with-local-llm)\n",
+      "- [Local RAG with Ollama and Weaviate](https://weaviate.io/blog/local-rag-with-ollama-and-weaviate)\n",
+      "- [Weaviate Quickstart](https://weaviate.io/developers/weaviate/quickstart/local)\n",
+      "\n",
+      "For more detailed discussions and issues, you can check the following GitHub links:\n",
+      "- [Issue #81](https://github.com/weaviate/Verba/issues/81)\n",
+      "- [Pull Request #133](https://github.com/weaviate/Verba/pull/133)\n",
+      "- [Pull Request #178](https://github.com/weaviate/Verba/pull/178)\n",
+      "- [Issue #171](https://github.com/weaviate/Verba/issues/171)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(response.response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 244,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "issues_client.close()\n",
+    "client.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "agent",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Description 
This recipe was used as a live coding demo after a meetup talk. It showcases the difference between naive rag and agents that have rag as tools. In the end, we build a 'weavaite assistant agent' that has access to 2 weaviate collections: docs and github issues. 
Users wanting to build with this recipe are told to connect their own collections. 

## Contribution Type
- [x] Integration
- [ ] Weaviate service
- [ ] Weaviate feature

## Promotion 
<!-- We'd love to promote your work on our socials! If you'd like a shoutout, please complete the section below. -->
- Personal X handle (optional): tuanacelik
- Personal LinkedIn account (optional): TuanaCelik