### PR TITLE
Langchain: Add SemanticSimilarityExampleSelector recipe

### DIFF
--- a/integrations/llm-agent-frameworks/langchain/example-selector-similarity/example.ipynb
+++ b/integrations/llm-agent-frameworks/langchain/example-selector-similarity/example.ipynb
@@ -1,0 +1,189 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_weaviate.vectorstores import WeaviateVectorStore\n",
+    "from langchain_core.example_selectors import SemanticSimilarityExampleSelector\n",
+    "from langchain_core.prompts import FewShotPromptTemplate, PromptTemplate\n",
+    "from langchain_openai import OpenAIEmbeddings\n",
+    "\n",
+    "example_prompt = PromptTemplate(\n",
+    "    input_variables=[\"input\", \"output\"],\n",
+    "    template=\"Input: {input}\\nOutput: {output}\",\n",
+    ")\n",
+    "\n",
+    "# Examples of a pretend task of creating antonyms.\n",
+    "examples = [\n",
+    "    {\"input\": \"happy\", \"output\": \"sad\"},\n",
+    "    {\"input\": \"tall\", \"output\": \"short\"},\n",
+    "    {\"input\": \"energetic\", \"output\": \"lethargic\"},\n",
+    "    {\"input\": \"sunny\", \"output\": \"gloomy\"},\n",
+    "    {\"input\": \"windy\", \"output\": \"calm\"},\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import weaviate\n",
+    "client = weaviate.connect_to_local()\n",
+    "client.collections.delete(\"MyExamples\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "example_selector = SemanticSimilarityExampleSelector.from_examples(\n",
+    "    # The list of examples available to select from.\n",
+    "    examples,\n",
+    "    # The embedding class used to produce embeddings which are used to measure semantic similarity.\n",
+    "    OpenAIEmbeddings(),\n",
+    "    # The VectorStore class that is used to store the embeddings and do a similarity search over.\n",
+    "    WeaviateVectorStore,\n",
+    "    client=client,\n",
+    "    index_name=\"MyExamples\",\n",
+    "    # The number of examples to produce.\n",
+    "    k=1,\n",
+    ")\n",
+    "similar_prompt = FewShotPromptTemplate(\n",
+    "    # We provide an ExampleSelector instead of examples.\n",
+    "    example_selector=example_selector,\n",
+    "    example_prompt=example_prompt,\n",
+    "    prefix=\"Give the antonym of every input\",\n",
+    "    suffix=\"Input: {adjective}\\nOutput:\",\n",
+    "    input_variables=[\"adjective\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Object(uuid=_WeaviateUUIDInt('472a3f11-fb4b-469a-a4c1-03b6efb2b289'), metadata=MetadataReturn(creation_time=None, last_update_time=None, distance=None, certainty=None, score=None, explain_score=None, is_consistent=None, rerank_score=None), properties={'text': 'tall short', 'input': 'tall', 'output': 'short'}, references=None, vector={}, collection='MyExamples'),\n",
+       " Object(uuid=_WeaviateUUIDInt('81846b44-b49e-429c-a176-4a346dfc54f2'), metadata=MetadataReturn(creation_time=None, last_update_time=None, distance=None, certainty=None, score=None, explain_score=None, is_consistent=None, rerank_score=None), properties={'text': 'sunny gloomy', 'input': 'sunny', 'output': 'gloomy'}, references=None, vector={}, collection='MyExamples'),\n",
+       " Object(uuid=_WeaviateUUIDInt('958e933b-a18e-4714-b6d9-03d8a970c458'), metadata=MetadataReturn(creation_time=None, last_update_time=None, distance=None, certainty=None, score=None, explain_score=None, is_consistent=None, rerank_score=None), properties={'text': 'happy sad', 'input': 'happy', 'output': 'sad'}, references=None, vector={}, collection='MyExamples'),\n",
+       " Object(uuid=_WeaviateUUIDInt('b929844f-40e1-4908-92eb-3e2efac98190'), metadata=MetadataReturn(creation_time=None, last_update_time=None, distance=None, certainty=None, score=None, explain_score=None, is_consistent=None, rerank_score=None), properties={'text': 'energetic lethargic', 'input': 'energetic', 'output': 'lethargic'}, references=None, vector={}, collection='MyExamples'),\n",
+       " Object(uuid=_WeaviateUUIDInt('f485e05c-9a1c-4b2a-b535-f4faa92ee494'), metadata=MetadataReturn(creation_time=None, last_update_time=None, distance=None, certainty=None, score=None, explain_score=None, is_consistent=None, rerank_score=None), properties={'text': 'windy calm', 'input': 'windy', 'output': 'calm'}, references=None, vector={}, collection='MyExamples')]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# those files are now in Weaviate\n",
+    "client.collections.get(\"MyExamples\").query.fetch_objects().objects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Give the antonym of every input\n",
+      "\n",
+      "Input: happy\n",
+      "Output: sad\n",
+      "\n",
+      "Input: worried\n",
+      "Output:\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(similar_prompt.format(adjective=\"worried\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Give the antonym of every input\n",
+      "\n",
+      "Input: tall\n",
+      "Output: short\n",
+      "\n",
+      "Input: large\n",
+      "Output:\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Input is a measurement, so should select the tall/short example\n",
+    "print(similar_prompt.format(adjective=\"large\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Give the antonym of every input\n",
+      "\n",
+      "Input: enthusiastic\n",
+      "Output: apathetic\n",
+      "\n",
+      "Input: passionate\n",
+      "Output:\n"
+     ]
+    }
+   ],
+   "source": [
+    "# You can add new examples to the SemanticSimilarityExampleSelector as well\n",
+    "similar_prompt.example_selector.add_example(\n",
+    "    {\"input\": \"enthusiastic\", \"output\": \"apathetic\"}\n",
+    ")\n",
+    "print(similar_prompt.format(adjective=\"passionate\"))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Weaviate recipes! Please fill out the information below and follow this checklist:

- Include the Weaviate and python client version and the other technologies used (if applicable) at the top of the notebook
    i.e. Weaviate version `1.25.3`, Weaviate python client `4.6.5`, and Unstructured `0.14.5`
- Add your name and social handles to the top of the notebook. You can use a company name if preferred!

p.s. If you work at Weaviate, please update or add to the [integration documentation](https://weaviate.io/developers/integrations) with a link to the notebook!
-->

## Description 
Added a Weaviate example as per the doc:
https://python.langchain.com/docs/how_to/example_selectors_similarity/

## Contribution Type
- [x] Integration
- [ ] Weaviate feature
- [ ] Weaviate service

## Promotion 
<!-- We'd love to promote your work on our socials! If you'd like a shoutout, please complete the section below. -->
- Personal X handle (optional): 
- Personal LinkedIn account (optional): 
- Company X handle:
- Company LinkedIn account:  
