### PR TITLE
feat: add MiniMax generative search recipe

### DIFF
--- a/weaviate-features/model-providers/minimax/rag_minimax_m2.7.ipynb
+++ b/weaviate-features/model-providers/minimax/rag_minimax_m2.7.ipynb
@@ -1,0 +1,373 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/weaviate/recipes/blob/main/weaviate-features/model-providers/minimax/rag_minimax_m2.7.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generative Search with MiniMax\n",
+    "\n",
+    "In this demo, we will use Weaviate's Embedding Service to index blog posts and use MiniMax's `MiniMax-M2.7` model to answer questions over the retrieved content.\n",
+    "\n",
+    "**What you will build:**\n",
+    "1. A Weaviate collection to store and search blog chunks using Weaviate's built-in embedding service.\n",
+    "2. A RAG pipeline that retrieves the top-K chunks from Weaviate and sends them to MiniMax for generation.\n",
+    "\n",
+    "MiniMax provides an [OpenAI-compatible Chat API](https://platform.minimax.io/docs/api-reference/text-openai-api) at `https://api.minimax.io/v1`, so we can use the `openai` Python SDK to call it.\n",
+    "\n",
+    "## Requirements\n",
+    "\n",
+    "1. Serverless Weaviate cluster (for the Weaviate Embedding Service)\n",
+    "    - You can create a 14-day free sandbox on [WCD](https://console.weaviate.cloud/)\n",
+    "2. MiniMax API key — sign up at [platform.minimax.io](https://platform.minimax.io/)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q weaviate-client openai"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import re\n",
+    "import json\n",
+    "\n",
+    "import weaviate\n",
+    "import weaviate.classes.config as wc\n",
+    "from weaviate.classes.config import Property, DataType\n",
+    "from weaviate.util import get_valid_uuid\n",
+    "from uuid import uuid4\n",
+    "from openai import OpenAI"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure Credentials"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "WCD_URL = os.environ[\"WEAVIATE_URL\"]       # Your Weaviate Cloud cluster URL\n",
+    "WCD_AUTH_KEY = os.environ[\"WEAVIATE_AUTH\"] # Your Weaviate Cloud API key\n",
+    "MINIMAX_API_KEY = os.environ[\"MINIMAX_API_KEY\"]  # Your MiniMax API key"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Connect to Weaviate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = weaviate.connect_to_wcs(\n",
+    "    cluster_url=WCD_URL,\n",
+    "    auth_credentials=weaviate.auth.AuthApiKey(WCD_AUTH_KEY),\n",
+    ")\n",
+    "\n",
+    "print(client.is_ready())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set Up MiniMax Client\n",
+    "\n",
+    "MiniMax provides an OpenAI-compatible API. We configure the `openai` SDK to point to MiniMax's base URL.\n",
+    "\n",
+    "Available MiniMax chat models:\n",
+    "| Model | Description |\n",
+    "|-------|-------------|\n",
+    "| `MiniMax-M2.7` | Peak Performance. Ultimate Value. Master the Complex. |\n",
+    "| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile. |\n",
+    "\n",
+    "API reference: https://platform.minimax.io/docs/api-reference/text-openai-api"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "minimax_client = OpenAI(\n",
+    "    api_key=MINIMAX_API_KEY,\n",
+    "    base_url=\"https://api.minimax.io/v1\",\n",
+    ")\n",
+    "\n",
+    "MINIMAX_MODEL = \"MiniMax-M2.7\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a Weaviate Collection\n",
+    "\n",
+    "We use Weaviate's built-in embedding service (`text2vec_weaviate`) so we only need the MiniMax key for generation — no separate embedding API key required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note: in practice, you shouldn't rerun this cell, as it deletes your data\n",
+    "# in \"BlogChunks\", and then you need to re-import it again.\n",
+    "\n",
+    "if client.collections.exists(\"BlogChunks\"):\n",
+    "    client.collections.delete(\"BlogChunks\")\n",
+    "\n",
+    "client.collections.create(\n",
+    "    name=\"BlogChunks\",\n",
+    "    vectorizer_config=wc.Configure.Vectorizer.text2vec_weaviate(\n",
+    "        model=\"Snowflake/snowflake-arctic-embed-l-v2.0\",\n",
+    "    ),\n",
+    "    properties=[\n",
+    "        Property(name=\"content\", data_type=DataType.TEXT)\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "print(\"Successfully created collection: BlogChunks.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Chunk and Import Data\n",
+    "\n",
+    "We read Weaviate blog posts from the shared `./data` folder, split them into sentence chunks, and import them into the collection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def chunk_list(lst, chunk_size):\n",
+    "    \"\"\"Break a list into chunks of the specified size.\"\"\"\n",
+    "    return [lst[i:i + chunk_size] for i in range(0, len(lst), chunk_size)]\n",
+    "\n",
+    "def split_into_sentences(text):\n",
+    "    \"\"\"Split text into sentences using regular expressions.\"\"\"\n",
+    "    sentences = re.split(r'(?<!\\w\\.\\w.)(?<![A-Z][a-z]\\.)(?<=\\.|\\?)\\s', text)\n",
+    "    return [sentence.strip() for sentence in sentences if sentence.strip()]\n",
+    "\n",
+    "def read_and_chunk_index_files(main_folder_path):\n",
+    "    \"\"\"Read .md/.mdx files, split into sentences, and chunk every 5 sentences.\"\"\"\n",
+    "    blog_chunks = []\n",
+    "    for file_path in os.listdir(main_folder_path):\n",
+    "        index_file_path = os.path.join(main_folder_path, file_path)\n",
+    "        if not os.path.isfile(index_file_path):\n",
+    "            continue\n",
+    "        with open(index_file_path, 'r', encoding='utf-8') as file:\n",
+    "            content = file.read()\n",
+    "            sentences = split_into_sentences(content)\n",
+    "            sentence_chunks = chunk_list(sentences, 5)\n",
+    "            blog_chunks.extend([' '.join(chunk) for chunk in sentence_chunks])\n",
+    "    return blog_chunks\n",
+    "\n",
+    "# The ./data folder is shared with other model-provider notebooks\n",
+    "main_folder_path = '../data'\n",
+    "blog_chunks = read_and_chunk_index_files(main_folder_path)\n",
+    "print(f\"Total chunks: {len(blog_chunks)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Preview the first chunk\n",
+    "blog_chunks[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "blogs = client.collections.get(\"BlogChunks\")\n",
+    "\n",
+    "for blog_chunk in blog_chunks:\n",
+    "    blogs.data.insert(\n",
+    "        properties={\"content\": blog_chunk},\n",
+    "        uuid=get_valid_uuid(uuid4())\n",
+    "    )\n",
+    "\n",
+    "print(f\"Inserted {len(blog_chunks)} chunks.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Retrieval — Hybrid Search\n",
+    "\n",
+    "Hybrid search combines BM25 keyword search with vector similarity search.\n",
+    "\n",
+    "- `alpha = 0` → pure BM25\n",
+    "- `alpha = 0.5` → half BM25, half vector search\n",
+    "- `alpha = 1` → pure vector search"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"What is Ref2Vec?\"\n",
+    "\n",
+    "blogs = client.collections.get(\"BlogChunks\")\n",
+    "response = blogs.query.hybrid(query=query, alpha=0.5, limit=3)\n",
+    "\n",
+    "retrieved_chunks = [obj.properties[\"content\"] for obj in response.objects]\n",
+    "for i, chunk in enumerate(retrieved_chunks, 1):\n",
+    "    print(f\"--- Chunk {i} ---\")\n",
+    "    print(chunk[:300])\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generation — MiniMax RAG\n",
+    "\n",
+    "We pass the retrieved chunks to MiniMax `MiniMax-M2.7` to generate a concise answer.\n",
+    "\n",
+    "> **Note:** MiniMax requires `temperature` in the range `(0.0, 1.0]`. The default is `1.0`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def rag_with_minimax(query: str, chunks: list[str], model: str = MINIMAX_MODEL) -> str:\n",
+    "    \"\"\"Retrieve context from Weaviate and generate an answer using MiniMax.\"\"\"\n",
+    "    context = \"\\n\\n\".join(chunks)\n",
+    "    prompt = (\n",
+    "        f\"Answer the following question based only on the provided context.\\n\\n\"\n",
+    "        f\"Context:\\n{context}\\n\\n\"\n",
+    "        f\"Question: {query}\\n\\n\"\n",
+    "        f\"Answer:\"\n",
+    "    )\n",
+    "\n",
+    "    completion = minimax_client.chat.completions.create(\n",
+    "        model=model,\n",
+    "        messages=[\n",
+    "            {\"role\": \"system\", \"content\": \"You are a helpful assistant. Answer concisely based on the provided context.\"},\n",
+    "            {\"role\": \"user\", \"content\": prompt},\n",
+    "        ],\n",
+    "        temperature=1.0,  # MiniMax requires temperature in (0.0, 1.0], default 1.0\n",
+    "        max_tokens=512,\n",
+    "    )\n",
+    "    return completion.choices[0].message.content\n",
+    "\n",
+    "\n",
+    "answer = rag_with_minimax(query, retrieved_chunks)\n",
+    "print(f\"Question: {query}\\n\")\n",
+    "print(f\"MiniMax Answer:\\n{answer}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Full RAG Pipeline\n",
+    "\n",
+    "The helper below combines retrieval and generation in one call."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def weaviate_minimax_rag(query: str, top_k: int = 3) -> str:\n",
+    "    \"\"\"End-to-end RAG: retrieve from Weaviate, generate with MiniMax.\"\"\"\n",
+    "    blogs = client.collections.get(\"BlogChunks\")\n",
+    "    response = blogs.query.hybrid(query=query, alpha=0.5, limit=top_k)\n",
+    "    chunks = [obj.properties[\"content\"] for obj in response.objects]\n",
+    "    return rag_with_minimax(query, chunks)\n",
+    "\n",
+    "\n",
+    "questions = [\n",
+    "    \"How does hybrid search work in Weaviate?\",\n",
+    "    \"What are the use cases for Ref2Vec?\",\n",
+    "]\n",
+    "\n",
+    "for q in questions:\n",
+    "    print(f\"Q: {q}\")\n",
+    "    print(f\"A: {weaviate_minimax_rag(q)}\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbformat_minor": 5,
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

- Add `weaviate-features/model-providers/minimax/rag_minimax_m2.7.ipynb` — an end-to-end RAG notebook using MiniMax's `MiniMax-M2.7` model.
- Uses Weaviate's built-in embedding service (`text2vec_weaviate`) for hybrid search retrieval, and MiniMax's OpenAI-compatible Chat API (`https://api.minimax.io/v1`) for generation.
- Only requires a MiniMax API key and a Weaviate Cloud account — no additional embedding API key needed.

## What's new

| | |
|---|---|
| **Notebook** | `weaviate-features/model-providers/minimax/rag_minimax_m2.7.ipynb` |
| **Model** | `MiniMax-M2.7` (also mentions `MiniMax-M2.7-highspeed`) |
| **API** | MiniMax OpenAI-compatible endpoint: `https://api.minimax.io/v1` |
| **Retrieval** | Weaviate hybrid search (BM25 + vector, `alpha=0.5`) |

## API References

- MiniMax Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api
- MiniMax Platform: https://platform.minimax.io/