### PR TITLE
Upgrade minimax RAG recipe default model to MiniMax-M3

### DIFF
--- a/weaviate-features/model-providers/minimax/rag_minimax_m3.ipynb
+++ b/weaviate-features/model-providers/minimax/rag_minimax_m3.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/weaviate/recipes/blob/main/weaviate-features/model-providers/minimax/rag_minimax_m2.7.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/weaviate/recipes/blob/main/weaviate-features/model-providers/minimax/rag_minimax_m3.ipynb)"
    ]
   },
   {
@@ -13,7 +13,7 @@
    "source": [
     "# Generative Search with MiniMax\n",
     "\n",
-    "In this demo, we will use Weaviate's Embedding Service to index blog posts and use MiniMax's `MiniMax-M2.7` model to answer questions over the retrieved content.\n",
+    "In this demo, we will use Weaviate's Embedding Service to index blog posts and use MiniMax's `MiniMax-M3` model to answer questions over the retrieved content.\n",
     "\n",
     "**What you will build:**\n",
     "1. A Weaviate collection to store and search blog chunks using Weaviate's built-in embedding service.\n",
@@ -105,6 +105,7 @@
     "Available MiniMax chat models:\n",
     "| Model | Description |\n",
     "|-------|-------------|\n",
+    "| `MiniMax-M3` | Next-generation flagship model. |\n",
     "| `MiniMax-M2.7` | Peak Performance. Ultimate Value. Master the Complex. |\n",
     "| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile. |\n",
     "\n",
@@ -122,7 +123,7 @@
     "    base_url=\"https://api.minimax.io/v1\",\n",
     ")\n",
     "\n",
-    "MINIMAX_MODEL = \"MiniMax-M2.7\""
+    "MINIMAX_MODEL = \"MiniMax-M3\""
    ]
   },
   {
@@ -267,7 +268,7 @@
    "source": [
     "## Generation — MiniMax RAG\n",
     "\n",
-    "We pass the retrieved chunks to MiniMax `MiniMax-M2.7` to generate a concise answer.\n",
+    "We pass the retrieved chunks to MiniMax `MiniMax-M3` to generate a concise answer.\n",
     "\n",
     "> **Note:** MiniMax requires `temperature` in the range `(0.0, 1.0]`. The default is `1.0`."
    ]


### PR DESCRIPTION
## Description

Updates the **minimax** model-providers RAG recipe so that its primary model is the latest **`MiniMax-M3`**.

Specifically:
- Adds `MiniMax-M3` to the available chat-model table and sets it as the default for the RAG demo (`MINIMAX_MODEL = \"MiniMax-M3\"`).
- Keeps `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` in the table as alternatives so users on older configurations continue to work.
- Renames `rag_minimax_m2.7.ipynb` to `rag_minimax_m3.ipynb` to match the existing per-model file naming convention used by other providers in this directory (e.g. `anthropic/rag_anthropic_claude-3-opus.ipynb`) and updates the Open in Colab badge to the new path.

The base URL (`https://api.minimax.io/v1`), API key env var (`MINIMAX_API_KEY`), and the temperature `(0.0, 1.0]` note are unchanged.

## Contribution Type
- [ ] Integration
- [x] Weaviate feature
- [ ] Weaviate service